### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/autolayout/src/main/AndroidManifest.xml
+++ b/autolayout/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
           package="com.zhy.autolayout">
 
     <application android:allowBackup="true"
-                 android:label="@string/app_name"
         >
 
     </application>


### PR DESCRIPTION
删除 android:label="@string/app_name"，解决tools:replace="android:label"无效问题